### PR TITLE
ci(codeclimate): setup codeclimate coverage reporting, maybe

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,13 @@ cache:
   directories:
     - ~/.npm
 
+before_script:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
+
 after_success:
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
   - npm run travis-deploy-once "npm run semantic-release"
 
 branches:


### PR DESCRIPTION
it's not really clear how the cc coverage reporter finds the lcov file, and the documentation is
pretty horrible, so this may fail... or surprise me by working magically